### PR TITLE
chore: go-demo-6 to 0.0.65

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,4 +12,4 @@ dependencies:
   version: 2.3.89
 - name: go-demo-6
   repository: http://jenkins-x-chartmuseum:8080
-  version: 1.0.378
+  version: 0.0.65


### PR DESCRIPTION
chore: Promote go-demo-6 to version 0.0.65